### PR TITLE
Removes admin123 password

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then open [http://localhost:8081](http://localhost:8081) and Nexus is running.
 There's no customization of the image so the default credentials apply:
 
 - username: `admin`
-- password: `admin123`
+- password: can be found on the file `/nexus-data/admin.password` inside the volume.
 
 You can change them once you login if you want.
 


### PR DESCRIPTION
The [docker image page](https://hub.docker.com/r/sonatype/nexus3) on Docker Hub states a different process to get the password
>   the uniquely generated password can be found in the admin.password file inside the volume

This PR updates the README.md so it correctly says how to get the password.